### PR TITLE
Move f3 hal to dev-dependencies and fix example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,15 @@ keywords = ["embedded-hal-driver", "pressure", "temperature", "sensor", "infineo
 categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dprotsiv/dps310-rs"
+
 [package.metadata.docs.rs]
 targets = ["thumbv6m-none-eabi"]
-[dependencies.embedded-hal]
-version = "0.2.4"
-[dev-dependencies.cortex-m]
-version = "0.6.4"
-[dev-dependencies.cortex-m-rt]
-version = "0.6.13"
-[dev-dependencies.panic-halt]
-version = "0.2.0"
 
-[dependencies.stm32f3]
-version = "0.12.1"
-features = ["stm32f303", "rt"]
+[dependencies]
+embedded-hal = "0.2"
+
+[dev-dependencies]
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+panic-halt = "0.2"
+stm32f3xx-hal = { version = "0.9", features = ["stm32f303xc", "rt"] }


### PR DESCRIPTION
The crate was not usable on any other target, because it always pulled in F3 HAL.

I moved it to `dev-dependencies` instead and also bumped versions. The example compiles, but I don't have an F3 board to test it.

I tested in on an STM32F429ZIT6 project instead and seems to work fine. Thanks for the crate!