### PR TITLE
Properly initialize coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ use dps310::{DPS310, self};
 let address = 0x77;
 let mut dps = DPS310::new(i2c, address, &dps310::Config::new()).unwrap();
 
+while !dps.init_complete().unwrap() || !dps.coef_ready().unwrap() {
+    delay.delay_ms(200_u8);
+}
+
+dps.read_calibration_coefficients().unwrap();
+
 dps.trigger_measurement(true, true, true).unwrap();
 
 if dps.data_ready().unwrap() {

--- a/examples/stm32f303vc.rs
+++ b/examples/stm32f303vc.rs
@@ -60,20 +60,22 @@ fn main() -> ! {
     );
 
     let mut dps = DPS310::new(i2c, ADDRESS, &dps310::Config::new()).unwrap();
-    let mut init_done = false;
+
     iprintln!(stim, "Wait for init done..");
-
-    while !init_done {
-        let compl = dps.init_complete();
-        init_done = match compl {
-            Ok(c) => c,
-            Err(_e) => false,
-        };
-
+    while !dps.init_complete().unwrap() {
         delay.delay_ms(200_u8);
     }
+    iprintln!(stim, "Sensor init done");
 
-    iprintln!(stim, "pressure sensor init done");
+    iprintln!(stim, "Wait for coef ready..");
+    while !dps.coef_ready().unwrap() {
+        delay.delay_ms(200_u8);
+    }
+    iprintln!(stim, "Sensor coefficients ready");
+
+    dps.read_calibration_coefficients().unwrap();
+    iprintln!(stim, "Sensor calibrated");
+
     dps.trigger_measurement(true, true, true).unwrap();
 
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,20 +170,20 @@ where
     pub fn init_complete(&mut self) -> Result<bool, E> {
         // see  sec 8.5, MEAS_CFG, SENSOR_RDY field (bit 6)
         let status = self.read_status()?;
-        Ok((status & 0x64) != 0)
+        Ok((status & (1 << 6)) != 0)
     }
 
     /// returns the temp_ready bit from the status register
     pub fn temp_ready(&mut self) -> Result<bool, E> {
         // See sec 8.5 TMP_RDY field
         let status = self.read_status()?;
-        Ok((status & 0x20) != 0)
+        Ok((status & (1 << 5)) != 0)
     }
 
     pub fn pres_ready(&mut self) -> Result<bool, E> {
         // See sec 8.5 PRS_RDY field
         let status = self.read_status()?;
-        Ok((status & 0x10) != 0)
+        Ok((status & (1 << 4)) != 0)
     }
 
     /// Read raw temperature contents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,20 @@ impl CalbrationCoeffs {
     }
 }
 
+#[derive(Debug)]
+pub enum Error<I2CError> {
+    /// I2C Interface Error
+    I2CError(I2CError),
+    /// Invalid measurement mode
+    InvalidMeasurementMode,
+}
+
+impl<I2CError> From<I2CError> for Error<I2CError> {
+    fn from(err: I2CError) -> Self {
+        Error::I2CError(err)
+    }
+}
+
 pub struct DPS310<I2C> {
     i2c: I2C,
     address: u8,
@@ -61,11 +75,11 @@ pub struct DPS310<I2C> {
     temp_res: TemperatureResolution,
 }
 
-impl<I2C, E> DPS310<I2C>
+impl<I2C, I2CError> DPS310<I2C>
 where
-    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+    I2C: i2c::WriteRead<Error = I2CError> + i2c::Write<Error = I2CError>,
 {
-    pub fn new(i2c: I2C, address: u8, config: &Config) -> Result<Self, E> {
+    pub fn new(i2c: I2C, address: u8, config: &Config) -> Result<Self, Error<I2CError>> {
         let mut dsp310 = Self {
             i2c,
             address,
@@ -85,7 +99,7 @@ where
         Ok(dsp310)
     }
 
-    fn apply_config(&mut self, config: &Config) -> Result<(), E> {
+    fn apply_config(&mut self, config: &Config) -> Result<(), Error<I2CError>> {
         // Sec 8.3 PRS_CFG register bits, PM_RATE & PM_PRC fields
         let prs_cfg = self.read_reg(Register::PRS_CFG)?;
 
@@ -127,20 +141,20 @@ where
     }
 
     /// Set measurement mode to `idle`
-    fn standby(&mut self) -> Result<(), E> {
+    fn standby(&mut self) -> Result<(), Error<I2CError>> {
         self.write_reg(Register::MEAS_CFG, 0)
     }
 
     /// Read status bits from MEAS_CFG reg.
     /// MEAS_CFG register is masked with 0xF0
-    pub fn read_status(&mut self) -> Result<u8, E> {
+    pub fn read_status(&mut self) -> Result<u8, Error<I2CError>> {
         let meas_cfg = self.read_reg(Register::MEAS_CFG)?;
         Ok(meas_cfg & 0xF0)
     }
 
     /// Returns the product ID from PROD_ID register.
     /// This value is expected to be 0x1D
-    pub fn get_product_id(&mut self) -> Result<u8, E> {
+    pub fn get_product_id(&mut self) -> Result<u8, Error<I2CError>> {
         // TODO: Make sure that both revision ID and product ID is supported. Sec 8.10
         self.read_reg(Register::PROD_ID)
     }
@@ -151,10 +165,10 @@ where
         temp: bool,
         pres: bool,
         continuous: bool,
-    ) -> Result<(), E> {
+    ) -> Result<(), Error<I2CError>> {
         if (!continuous && temp && pres) || (continuous && !temp && !pres) {
             // unsupported mode, See Sec 8.5 (MEAS_CFG), MEAS_CTRL field values
-            // FIXME: Implement error return
+            return Err(Error::InvalidMeasurementMode);
         }
         // See section 8.5, MEAS_CTRL field description in manual
 
@@ -166,35 +180,35 @@ where
     }
 
     /// Returns true if sensor coeficients are available
-    pub fn coef_ready(&mut self) -> Result<bool, E> {
+    pub fn coef_ready(&mut self) -> Result<bool, Error<I2CError>> {
         // see  sec 8.5, MEAS_CFG, COEF_RDY field (bit 7)
         let status = self.read_status()?;
         Ok((status & (1 << 7)) != 0)
     }
 
     /// Returns true if sensor initialized and ready to take measurements
-    pub fn init_complete(&mut self) -> Result<bool, E> {
+    pub fn init_complete(&mut self) -> Result<bool, Error<I2CError>> {
         // see  sec 8.5, MEAS_CFG, SENSOR_RDY field (bit 6)
         let status = self.read_status()?;
         Ok((status & (1 << 6)) != 0)
     }
 
     /// Returns true if temperature measurement is ready
-    pub fn temp_ready(&mut self) -> Result<bool, E> {
+    pub fn temp_ready(&mut self) -> Result<bool, Error<I2CError>> {
         // See sec 8.5 TMP_RDY field
         let status = self.read_status()?;
         Ok((status & (1 << 5)) != 0)
     }
 
     /// Returns true if pressure measurement is ready
-    pub fn pres_ready(&mut self) -> Result<bool, E> {
+    pub fn pres_ready(&mut self) -> Result<bool, Error<I2CError>> {
         // See sec 8.5 PRS_RDY field
         let status = self.read_status()?;
         Ok((status & (1 << 4)) != 0)
     }
 
     /// Read raw temperature contents
-    fn read_temp_raw(&mut self) -> Result<i32, E> {
+    fn read_temp_raw(&mut self) -> Result<i32, Error<I2CError>> {
         let mut bytes: [u8; 3] = [0, 0, 0];
         self.i2c
             .write_read(self.address, &[Register::TMP_B2.addr()], &mut bytes)?;
@@ -205,7 +219,7 @@ where
     }
 
     /// See section 4.9.2:
-    fn read_temp_scaled(&mut self) -> Result<f32, E> {
+    fn read_temp_scaled(&mut self) -> Result<f32, Error<I2CError>> {
         let raw_sc: f32 = self.read_temp_raw()? as f32 / self.temp_res.get_kt_value();
         Ok(raw_sc)
     }
@@ -216,7 +230,7 @@ where
     /// which have to be initialized with [Self::read_calibration_coefficients()] beforehand.
     /// 
     /// See section 4.9.2 in the datasheet (formula), Sec 8.11 (coefficients)
-    pub fn read_temp_calibrated(&mut self) -> Result<f32, E> {
+    pub fn read_temp_calibrated(&mut self) -> Result<f32, Error<I2CError>> {
         let scaled = self.read_temp_scaled();
         match scaled {
             Ok(raw_sc) => Ok((self.coeffs.C0 as f32 * 0.5) + (self.coeffs.C1 as f32 * raw_sc)),
@@ -225,7 +239,7 @@ where
     }
 
     /// Read raw pressure contents
-    pub fn read_pressure_raw(&mut self) -> Result<i32, E> {
+    pub fn read_pressure_raw(&mut self) -> Result<i32, Error<I2CError>> {
         let mut bytes: [u8; 3] = [0, 0, 0];
         self.i2c
             .write_read(self.address, &[Register::PSR_B2.addr()], &mut bytes)?;
@@ -236,7 +250,7 @@ where
         Ok(pressure)
     }
 
-    fn read_pressure_scaled(&mut self) -> Result<f32, E> {
+    fn read_pressure_scaled(&mut self) -> Result<f32, Error<I2CError>> {
         let pres_raw = self.read_pressure_raw()?;
         let k_p = self.pres_res.get_kP_value();
         let pres_scaled = pres_raw as f32 / k_p;
@@ -251,7 +265,7 @@ where
     /// 
     /// See section 8.11 in the datasheet.
     /// See section 4.9.1 for calculation method.
-    pub fn read_pressure_calibrated(&mut self) -> Result<f32, E> {
+    pub fn read_pressure_calibrated(&mut self) -> Result<f32, Error<I2CError>> {
         let pres_scaled = self.read_pressure_scaled()?;
         let temp_scaled = self.read_temp_scaled()?;
 
@@ -269,16 +283,17 @@ where
     }
 
     /// Issue a full reset and fifo flush
-    pub fn reset(&mut self) -> Result<(), E> {
+    pub fn reset(&mut self) -> Result<(), Error<I2CError>> {
         self.write_reg(Register::RESET, 0b10001001)
     }
 
-    fn write_reg(&mut self, reg: Register, value: u8) -> Result<(), E> {
+    fn write_reg(&mut self, reg: Register, value: u8) -> Result<(), Error<I2CError>> {
         let bytes = [reg.addr(), value];
-        self.i2c.write(self.address, &bytes)
+        self.i2c.write(self.address, &bytes)?;
+        Ok(())
     }
 
-    fn read_reg(&mut self, reg: Register) -> Result<u8, E> {
+    fn read_reg(&mut self, reg: Register) -> Result<u8, Error<I2CError>> {
         let mut buffer: [u8; 1] = [0];
         self.i2c
             .write_read(self.address, &[reg.addr()], &mut buffer)?;
@@ -290,7 +305,7 @@ where
     /// Taken from official Arduino library, see <https://github.com/Infineon/DPS310-Pressure-Sensor/blob/888200c7efd8edb19ce69a2144e28ba31cdad449/src/Dps310.cpp#L89>
     /// 
     /// See Sec 8.11
-    pub fn read_calibration_coefficients(&mut self) -> Result<(), E> {
+    pub fn read_calibration_coefficients(&mut self) -> Result<(), Error<I2CError>> {
         let mut bytes: [u8; 18] = [0; 18];
 
         self.i2c

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //!
-//! DSP310 embedded-hal I2C driver crate
+//! DPS310 embedded-hal I2C driver crate
 //!
 //! A platform agnostic driver to interface with the DSP310 barometric pressure & temp sensor.
 //! This driver uses I2C via [embedded-hal]. Note that the DSP310 also supports SPI, however that
@@ -165,27 +165,28 @@ where
         self.write_reg(Register::MEAS_CFG, meas_cfg)
     }
 
-    /// returns true if sensor coeficients are available
+    /// Returns true if sensor coeficients are available
     pub fn coef_ready(&mut self) -> Result<bool, E> {
         // see  sec 8.5, MEAS_CFG, COEF_RDY field (bit 7)
         let status = self.read_status()?;
         Ok((status & (1 << 7)) != 0)
     }
 
-    /// returns the sensor_ready bit from the status register
+    /// Returns true if sensor initialized and ready to take measurements
     pub fn init_complete(&mut self) -> Result<bool, E> {
         // see  sec 8.5, MEAS_CFG, SENSOR_RDY field (bit 6)
         let status = self.read_status()?;
         Ok((status & (1 << 6)) != 0)
     }
 
-    /// returns the temp_ready bit from the status register
+    /// Returns true if temperature measurement is ready
     pub fn temp_ready(&mut self) -> Result<bool, E> {
         // See sec 8.5 TMP_RDY field
         let status = self.read_status()?;
         Ok((status & (1 << 5)) != 0)
     }
 
+    /// Returns true if pressure measurement is ready
     pub fn pres_ready(&mut self) -> Result<bool, E> {
         // See sec 8.5 PRS_RDY field
         let status = self.read_status()?;
@@ -212,7 +213,7 @@ where
     /// Read calibrated temperature data in degrees Celsius.
     /// 
     /// This method uses the pre calculated constants based on the calibration coefficients
-    /// which have to be initialized with [read_calibration_coefficients()] beforehand.
+    /// which have to be initialized with [Self::read_calibration_coefficients()] beforehand.
     /// 
     /// See section 4.9.2 in the datasheet (formula), Sec 8.11 (coefficients)
     pub fn read_temp_calibrated(&mut self) -> Result<f32, E> {
@@ -246,7 +247,7 @@ where
     /// Read calibrated pressure data in Pa.
     /// 
     /// This method uses the pre calculated constants based on the calibration coefficients
-    /// which have to be initialized with [read_calibration_coefficients()] beforehand.
+    /// which have to be initialized with [Self::read_calibration_coefficients()] beforehand.
     /// 
     /// See section 8.11 in the datasheet.
     /// See section 4.9.1 for calculation method.
@@ -284,9 +285,10 @@ where
         Ok(buffer[0])
     }
 
-    /// Read calibration coefficients. Taken from official Arduino library
+    /// Read calibration coefficients. User must wait for `Self::coef_ready()` to return true before reading coefficients.
     ///
-    /// See https://github.com/Infineon/DPS310-Pressure-Sensor/blob/888200c7efd8edb19ce69a2144e28ba31cdad449/src/Dps310.cpp#L89
+    /// Taken from official Arduino library, see <https://github.com/Infineon/DPS310-Pressure-Sensor/blob/888200c7efd8edb19ce69a2144e28ba31cdad449/src/Dps310.cpp#L89>
+    /// 
     /// See Sec 8.11
     pub fn read_calibration_coefficients(&mut self) -> Result<(), E> {
         let mut bytes: [u8; 18] = [0; 18];


### PR DESCRIPTION
Coefficients are not available immediately after power up and must only be read when `COEF_RDY` bit is set in `MEAS_CFG` register. Otherwise, if sensor is initialized too soon, the measurements are incorrect. Hence I exposed the `read_calibration_coefficients()` to the user and added an accompanying `coef_ready()`.

Also fixed wrong mask for the `init_complete()` (although it happened to work due to additional mask in `read_status()`) and properly implemented lib-specific error handling by adding `Error::InvalidMeasurementMode`.

This needs a minor version bump, since user now has to call `read_calibration_coefficients()`.