### PR TITLE
Update to embedded_hal 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ repository = "https://github.com/dprotsiv/dps310-rs"
 targets = ["thumbv6m-none-eabi"]
 
 [dependencies]
-embedded-hal = "0.2"
+embedded-hal = "1.0"
 
 [dev-dependencies]
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 panic-halt = "0.2"
-stm32f3xx-hal = { version = "0.9", features = ["stm32f303xc", "rt"] }
+stm32f3xx-hal = { version = "0.10", features = ["stm32f303xc", "rt"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,7 @@
 mod config;
 mod register;
 
-use embedded_hal as hal;
-use hal::blocking::i2c;
+use embedded_hal::i2c::I2c;
 
 pub use config::*;
 pub use register::Register;
@@ -77,7 +76,7 @@ pub struct DPS310<I2C> {
 
 impl<I2C, I2CError> DPS310<I2C>
 where
-    I2C: i2c::WriteRead<Error = I2CError> + i2c::Write<Error = I2CError>,
+    I2C: I2c<Error = I2CError>,
 {
     pub fn new(i2c: I2C, address: u8, config: &Config) -> Result<Self, Error<I2CError>> {
         let mut dsp310 = Self {


### PR DESCRIPTION
Updated to the new EH 1.0

A minor version bump to `0.2` is required to not break semver